### PR TITLE
Add additional padding for iPhone X

### DIFF
--- a/ImagePickerSheetController/ImagePickerSheetController/ImagePickerSheetController.swift
+++ b/ImagePickerSheetController/ImagePickerSheetController/ImagePickerSheetController.swift
@@ -321,10 +321,17 @@ open class ImagePickerSheetController: UIViewController {
         let sheetHeight = sheetController.preferredSheetHeight
         let sheetSize = CGSize(width: view.bounds.width, height: sheetHeight)
         
+        let additionalPadding: CGFloat
+        if #available(iOS 11, *) {
+            additionalPadding = view.safeAreaInsets.bottom
+        } else {
+            additionalPadding = 0
+        }
+        
         // This particular order is necessary so that the sheet is layed out
         // correctly with and without an enclosing popover
         preferredContentSize = sheetSize
-        sheetCollectionView.frame = CGRect(origin: CGPoint(x: view.bounds.minX, y: view.bounds.maxY - view.frame.origin.y - sheetHeight), size: sheetSize)
+        sheetCollectionView.frame = CGRect(origin: CGPoint(x: view.bounds.minX, y: view.bounds.maxY - view.frame.origin.y - sheetHeight - additionalPadding), size: sheetSize)
     }
     
     fileprivate func reloadCurrentPreviewHeight(invalidateLayout invalidate: Bool) {

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You should also add two new values to your app's `Info.plist` to tell the user w
 ```
 
 ## Requirements
-ImagePickerSheetController is written in Swift and links against `Photos.framework`. It therefore requires iOS 8 or later.
+ImagePickerSheetController is written in Swift and links against `Photos.framework`. It therefore requires iOS 9.0 or later.
 
 ## Author
 I'm Laurin Brandner, I'm on [Twitter](https://twitter.com/lbrndnr).

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ pod "ImagePickerSheetController", "~> 0.9.1"
 github "lbrndnr/ImagePickerSheetController" ~> 0.9.1
 ```
 
+You should also add two new values to your app's `Info.plist` to tell the user why your app need to access the Camera and Photo Library.
+```
+<key>NSCameraUsageDescription</key>
+<string>Camera usage description</string>
+<key>NSPhotoLibraryUsageDescription</key>
+<string>Photo Library usage description</string>
+```
+
 ## Requirements
 ImagePickerSheetController is written in Swift and links against `Photos.framework`. It therefore requires iOS 8 or later.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ## About
 ImagePickerSheetController is a component that replicates the custom photo action sheet in iMessage. It's very similar to UIAlertController which makes its usage simple and concise.
+⚠️You can also find an iOS 10 version of this library [here](https://github.com/lbrndnr/ImagePickerTrayController)⚠️
 
 ![Screenshot](https://raw.githubusercontent.com/lbrndnr/ImagePickerSheetController/master/Screenshots/GoT.gif)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pod "ImagePickerSheetController", "~> 0.9.1"
 github "lbrndnr/ImagePickerSheetController" ~> 0.9.1
 ```
 
-You should also add two new values to your app's `Info.plist` to tell the user why your app need to access the Camera and Photo Library.
+You should also add two new values to your app's `Info.plist` to tell the user why you need to access the Camera and Photo Library.
 ```
 <key>NSCameraUsageDescription</key>
 <string>Camera usage description</string>


### PR DESCRIPTION
Add additional padding so picker doesn't overlap with iPhone X home indicator.

# Before

![simulator screen shot - iphone2017-c - 2017-10-13 at 14 51 20](https://user-images.githubusercontent.com/6910829/31561492-0a9b9e6a-b026-11e7-860d-dd142736f738.png)

# After

![simulator screen shot - iphone2017-c - 2017-10-13 at 14 50 33](https://user-images.githubusercontent.com/6910829/31561488-07c299b4-b026-11e7-934d-d1933317c200.png)

